### PR TITLE
Add WPML language support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2025-07-09
+
+### Features
+
+- Added Colombian fields for document type and number when syncing customers.
+- Partner state is now mapped based on WooCommerce billing state code.
+- Added WPML language compatibility for product and order imports.
+
 ## 2025-06-24
 
 ### Features

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ The **Odoo-WooCommerce Sync** add-on enables synchronization between WooCommerce
 - **Automated and Manual Synchronization:** A built-in cron job scheduler enables regular synchronization, complemented by a dedicated button for manually triggering updates.
 - **Advanced Settings:** Support for multiple WooCommerce websites with specific configuration options for each instance (e.g. syncing only products from WooCommerce to Odoo).
 - **Image Synchronization:** Optionally synchronize product images from WooCommerce to Odoo. For products imported from WooCommerce that include multiple images/product gallery, an additional product gallery is added to the `product.template` view.
-- **Language Filtering:** Synchronize products by language (*requires Polylang*).
+- **Language Filtering:** Synchronize products by language (*requires Polylang or WPML*).
 - **Orders Transactions Fee Support:** Integrates additional fee fields into orders processed with PayPal and Stripe (*requires the respective plugins*).
 
 Some features require additional setup, as detailed in the [Requirements](#requirements) section.
@@ -102,9 +102,10 @@ Brazil:
 #### WordPress Plugins (Optional)
 
 - **WooCommerce Customer Last Login:** (`woocommerce_customer_date_last_login` field): Requires the [Wordfence Security](https://wordpress.org/plugins/wordfence/) plugin.
-- **Product Language Code:** (`product_language_code` field): Requires [Polylang for WooCommerce](https://polylang.pro/downloads/polylang-for-woocommerce/) and either:
-  - [Polylang Pro](https://polylang.pro/downloads/polylang-pro/) (which enables the `lang` argument in the WooCommerce REST API); or
-  - The custom code snippet provided in [this file](./woocommerce-rest-api/woocommerce-rest-api-polylang-language-slug.php), saved either into the `functions.php` file or into a code snippet plugin (e.g. [WPCode](https://wordpress.org/plugins/insert-headers-and-footers/)).
+- **WooCommerce Multilingual & Multicurrency:** Provides WPML compatibility for WooCommerce REST API.
+- **Product Language Code:** (`product_language_code` field): Requires [Polylang for WooCommerce](https://polylang.pro/downloads/polylang-for-woocommerce/) or [WooCommerce Multilingual & Multicurrency](https://wpml.org/plugin/woocommerce-multilingual/) and either:
+  - [Polylang Pro](https://polylang.pro/downloads/polylang-pro/) (which enables the `lang` argument in the WooCommerce REST API) or WPML's REST API filters; or
+  - The custom code snippets provided in [these files](./woocommerce-rest-api/woocommerce-rest-api-polylang-language-slug.php) and [this WPML version](./woocommerce-rest-api/woocommerce-rest-api-wpml-language-slug.php), saved either into the `functions.php` file or into a code snippet plugin (e.g. [WPCode](https://wordpress.org/plugins/insert-headers-and-footers/)).
 - **Orders Transactions Fee** (`woocommerce_order_transaction_fee` field): Requires the [WooCommerce PayPal Payments](https://wordpress.org/plugins/woocommerce-paypal-payments/) and/or [Payment Plugins for Stripe WooCommerce](https://wordpress.org/plugins/woo-stripe-payment/) plugin.
   - For the [Payment Plugins for Stripe WooCommerce](https://wordpress.org/plugins/woo-stripe-payment/), the following setting needs to be changed in order to enable the Stripe transaction fee field: `WooCommerce` > `Stripe by Payment Plugins` > `Settings` > `Advanced Settings` > Enable `Display Stripe Fee`.
 

--- a/woocommerce-rest-api/woocommerce-rest-api-wpml-language-slug.php
+++ b/woocommerce-rest-api/woocommerce-rest-api-wpml-language-slug.php
@@ -1,0 +1,26 @@
+<?php
+// WooCommerce - Add WPML language slug to WooCommerce Rest API
+// Last update: 2025-07-09
+
+if (class_exists('WooCommerce') && WC() && defined('ICL_SITEPRESS_VERSION')) {
+    add_filter('woocommerce_rest_product_object_query', function ($args, $request) {
+        if ($request->get_param('lang')) {
+            $args['lang'] = sanitize_text_field($request->get_param('lang'));
+        }
+        return $args;
+    }, 10, 2);
+
+    add_action('rest_api_init', function () {
+        $post_types = ['product', 'shop_order'];
+
+        foreach ($post_types as $post_type) {
+            register_rest_field($post_type, 'lang', [
+                'get_callback' => function ($object) {
+                    $details = apply_filters('wpml_post_language_details', null, $object['id']);
+                    return isset($details['language_code']) ? $details['language_code'] : null;
+                },
+                'schema' => ['description' => __('Language of the post', 'wpml'), 'type' => 'string'],
+            ]);
+        }
+    }, 10, 1);
+}

--- a/woocommerce_sync/models/models.py
+++ b/woocommerce_sync/models/models.py
@@ -827,7 +827,13 @@ class WoocommerceConnector(models.Model):
             {
                 'product_sync_to_woocommerce': True,
                 'product_source': 'WooCommerce',
-                'product_language_code': woocommerce_product.get('lang', None),  # Polylang field
+                'product_language_code': (
+                    woocommerce_product.get('lang')
+                    or next(
+                        (meta['value'] for meta in woocommerce_product.get('meta_data', []) if meta.get('key') == 'wpml_language'),
+                        None,
+                    )
+                ),
                 'woocommerce_product_service': False,  # woocommerce_product.get('service', False), # Germanized field - https://vendidero.de/doc/woocommerce-germanized/products-rest-api
             },
         )
@@ -1460,6 +1466,17 @@ class WoocommerceConnector(models.Model):
                             'woocommerce_customer_date_last_login': datetime.fromtimestamp(int(meta['value']))
                             if (meta := next((meta for meta in customer['meta_data'] if meta.get('key') == 'wfls-last-login'), None))
                             else None,  # Wordfence Security field
+                            'woocommerce_customer_identification_type': customer['billing'].get('tipoIdentificacion')
+                            or next((meta['value'] for meta in customer['meta_data'] if meta.get('key') in ('tipo_identificacion', 'tipoIdentificacion')), None),
+                            'woocommerce_customer_identification_number': customer['billing'].get('billingId')
+                            or next((meta['value'] for meta in customer['meta_data'] if meta.get('key') in ('billing_id', '_billing_id')), None),
+                            'woocommerce_customer_language_code': (
+                                customer.get('lang')
+                                or next(
+                                    (meta['value'] for meta in customer['meta_data'] if meta.get('key') == 'wpml_language'),
+                                    None,
+                                )
+                            ),
                         },
                     )
 
@@ -1494,12 +1511,16 @@ class WoocommerceConnector(models.Model):
                             'user_id': woocommerce_sync_config.settings_woocommerce_user_responsible.id,
                             # Customer status
                             'active': True,
+                            'lang': customer_values['woocommerce_customer_language_code'],
                             # Address
                             'street': customer_values['woocommerce_customer_billing_address_1'],
                             'street2': customer_values['woocommerce_customer_billing_address_2'],
                             'city': customer_values['woocommerce_customer_billing_city'],
                             'zip': customer_values['woocommerce_customer_billing_postcode'],
                             'country_id': self.env['res.country'].search([('code', '=', customer_values['woocommerce_customer_billing_country'])], limit=1).id,
+                            'state_id': self.env['res.country.state']
+                            .search([('code', '=', customer_values['woocommerce_customer_billing_state']), ('country_id.code', '=', customer_values['woocommerce_customer_billing_country'])], limit=1)
+                            .id,
                         },
                     )
 
@@ -1643,7 +1664,13 @@ class WoocommerceConnector(models.Model):
                         )
                     order_values.update(
                         {
-                            'order_language_code': order.get('lang', None),  # Polylang field
+                            'order_language_code': (
+                                order.get('lang')
+                                or next(
+                                    (meta['value'] for meta in order.get('meta_data', []) if meta.get('key') == 'wpml_language'),
+                                    None,
+                                )
+                            ),
                         },
                     )
 
@@ -1695,6 +1722,17 @@ class WoocommerceConnector(models.Model):
                                     'woocommerce_customer_billing_country': order['billing']['country'],
                                     'woocommerce_customer_billing_email': order['billing']['email'],
                                     'woocommerce_customer_billing_phone': order['billing']['phone'],
+                                    'woocommerce_customer_identification_type': order['billing'].get('tipoIdentificacion')
+                                    or next((meta['value'] for meta in order['meta_data'] if meta.get('key') in ('tipo_identificacion', 'tipoIdentificacion')), None),
+                                    'woocommerce_customer_identification_number': order['billing'].get('billingId')
+                                    or next((meta['value'] for meta in order['meta_data'] if meta.get('key') in ('billing_id', '_billing_id')), None),
+                                    'woocommerce_customer_language_code': (
+                                        order.get('lang')
+                                        or next(
+                                            (meta['value'] for meta in order['meta_data'] if meta.get('key') == 'wpml_language'),
+                                            None,
+                                        )
+                                    ),
                                 },
                             )
 
@@ -1732,12 +1770,16 @@ class WoocommerceConnector(models.Model):
                                     'user_id': woocommerce_sync_config.settings_woocommerce_user_responsible.id,
                                     # Customer status
                                     'active': True,
+                                    'lang': customer_values['woocommerce_customer_language_code'],
                                     # Address
                                     'street': customer_values['woocommerce_customer_billing_address_1'],
                                     'street2': customer_values['woocommerce_customer_billing_address_2'],
                                     'city': customer_values['woocommerce_customer_billing_city'],
                                     'zip': customer_values['woocommerce_customer_billing_postcode'],
                                     'country_id': self.env['res.country'].search([('code', '=', customer_values['woocommerce_customer_billing_country'])], limit=1).id,
+                                    'state_id': self.env['res.country.state']
+                                    .search([('code', '=', customer_values['woocommerce_customer_billing_state']), ('country_id.code', '=', customer_values['woocommerce_customer_billing_country'])], limit=1)
+                                    .id,
                                 },
                             )
 

--- a/woocommerce_sync/models/woocommerce_models.py
+++ b/woocommerce_sync/models/woocommerce_models.py
@@ -386,6 +386,11 @@ class ResPartner(models.Model):
     # Custom fields
     woocommerce_customer_date_last_login = fields.Datetime(string='Last Login Date', readonly=True)  # Wordfence fields
 
+    # Colombian localization fields
+    woocommerce_customer_identification_type = fields.Char(string='Document Type', readonly=True)
+    woocommerce_customer_identification_number = fields.Char(string='Document Number', readonly=True)
+    woocommerce_customer_language_code = fields.Char(string='Language', help='Polylang or WPML 2-digit ISO 639-1 language code.', readonly=True)
+
 
 # Orders
 class SaleOrder(models.Model):


### PR DESCRIPTION
## Summary
- support WPML language on product and order import
- store WooCommerce language on partners and map to `lang`
- update readme with WPML integration steps
- include helper snippet for WPML REST API language slug

## Testing
- `pre-commit run --files changelog.md readme.md woocommerce_sync/models/models.py woocommerce_sync/models/woocommerce_models.py woocommerce-rest-api/woocommerce-rest-api-wpml-language-slug.php`


------
https://chatgpt.com/codex/tasks/task_e_6870b5ba64a08332b5938ab0b715076d